### PR TITLE
FIX(jl): output IR0+ artifacts using non-nested file extensions.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,8 @@ fn main() {
     let out_fname = matches.value_of("output_file").unwrap();
     let base_fname = Path::new(out_fname)
         .file_stem()
-        .expect("Failed to generate base file name")
-        .to_str()
-        .expect("Failed to parse base_fname string");
+        .and_then(|s| s.to_str())
+        .expect("Failed to parse base_fname from output path");
 
     let maybe_arith = matches.value_of("arithmetic_circuit");
     let maybe_bool = matches.value_of("boolean_circuit");


### PR DESCRIPTION
Prior, the IR0+ export logic, generally,
1. input `out_fname`
2. depending on `out_fname.ends_with`, export different backends (here `out_fname.ends_with(".circuit")` will execute IR0+ codepath)
3. pass that `out_fname` to all export logic, as all but IR0+ backends only have one export artifact.
4. for the IR0+ backend, as a hack, just append `.{public,private}_input` to that `.circuit` path.

so the result is `foo.circuit`, `foo.circuit.public_input`, `foo.circuit.private_input`.

here, fix to use `Path::file_stem` to remove the output file extension, and instead pass around a 'base name'.