### PR TITLE
Use `log` log levels in place of `println!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +489,7 @@ dependencies = [
  "fnv",
  "indicatif",
  "itertools",
+ "log",
  "maplit",
  "mcircuit",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1.0.71"
 bincode = "1.3.2"
 clap = { version = "4.4.3", features = ["derive"]}
 counter = "0.5.2"
-env_logger = "0.9.0"
 fnv = "1.0.7"
 indicatif = "0.17.4"
 itertools = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,22 @@ description = "Converts circuits in the BLIF circuit format to composite boolean
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-petgraph = "0.6.3"
-maplit = "1.0.2"
-rand = "0.7.3"
-counter = "0.5.2"
+anyhow = "1.0.71"
+bincode = "1.3.2"
 clap = { version = "4.4.3", features = ["derive"]}
+counter = "0.5.2"
+env_logger = "0.9"
+fnv = "1.0.7"
+indicatif = "0.17.4"
 itertools = "0.12.0"
+log = "0.4"
+maplit = "1.0.2"
 mcircuit = { git = "https://github.com/trailofbits/mcircuit", branch = "main" }
 num-traits = "0.2"
+petgraph = "0.6.3"
+rand = "0.7.3"
 serde = "1.0.163"
-bincode = "1.3.2"
-indicatif = "0.17.4"
-fnv = "1.0.7"
 thiserror = "1.0.40"
-anyhow = "1.0.71"
 
 [lib]
 name = "sv_circuit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.71"
 bincode = "1.3.2"
 clap = { version = "4.4.3", features = ["derive"]}
 counter = "0.5.2"
-env_logger = "0.9"
+env_logger = "0.9.0"
 fnv = "1.0.7"
 indicatif = "0.17.4"
 itertools = "0.12.0"

--- a/src/generic/circuit.rs
+++ b/src/generic/circuit.rs
@@ -367,8 +367,8 @@ where
             .iter()
             .map(|i| &i.name)
             .collect::<Counter<_>>();
-        for (name, count) in submod_counts.most_common_ordered() {
-            log::debug!("    {name}: {count}");
+        for (subcircuit, frequency) in submod_counts.most_common_ordered() {
+            log::debug!("{}: merge {frequency}x {subcircuit}(s)", self.name);
         }
 
         // Iterate over all the subcircuit descriptors

--- a/src/generic/circuit.rs
+++ b/src/generic/circuit.rs
@@ -589,7 +589,11 @@ where
             }
         }
 
-        log::warn!("Expected max_wire was {}, actual was {}", self.graph.edge_count() + self.inputs.len() + self.outputs.len(), max_wire);
+        log::warn!(
+            "Expected max_wire was {}, actual was {}",
+            self.graph.edge_count() + self.inputs.len() + self.outputs.len(),
+            max_wire
+        );
         max_wire
     }
 

--- a/src/generic/circuit.rs
+++ b/src/generic/circuit.rs
@@ -201,7 +201,7 @@ where
                 // Warn if this buffer maps an output to an output. I don't think it breaks
                 // anything, but it's weird.
                 if self.outputs.contains(&out) && self.outputs.contains(&src) {
-                    eprintln!("Instruction: BUF {src} --> {out} maps an output to an output");
+                    log::debug!("Instruction: BUF {src} --> {out} maps an output to an output");
                 }
 
                 // If this buffer doesn't connect to any gates, it probably transparently maps
@@ -368,7 +368,7 @@ where
             .map(|i| &i.name)
             .collect::<Counter<_>>();
         for (name, count) in submod_counts.most_common_ordered() {
-            println!("    {name}: {count}");
+            log::debug!("    {name}: {count}");
         }
 
         // Iterate over all the subcircuit descriptors
@@ -442,7 +442,7 @@ where
                         //             missing.insert(*i);
                         //         }
                         //     }
-                        //     eprintln!(
+                        //     elog::debug!(
                         //         "Warning: subcircuit {} drops {} bits of input: {:?}",
                         //         desc.name,
                         //         missing.len(),
@@ -509,18 +509,18 @@ where
             }
         }
 
-        println!("Adding missing wires...");
+        log::debug!("Adding missing wires...");
         // We call the `build` operation, which is necessary to make the edges in our underlying
         // graph (assuming the gates weren't already topologically sorted)
-        println!("Created {} wires", merged._build()?);
+        log::debug!("Created {} wires", merged._build()?);
         // We undo the remappings on any IO wires for this subcircuit
         // We attempt to squash the buffer gates that we used to connect the parent circuits to
         // the subcircuits
-        println!("Squashing extra buffer gates");
-        println!("Removed {} buffers", merged.prune());
+        log::debug!("Squashing extra buffer gates");
+        log::debug!("Removed {} buffers", merged.prune());
 
-        println!("Currying constant gates");
-        println!("Removed {} constant gates", merged.curry());
+        log::debug!("Currying constant gates");
+        log::debug!("Removed {} constant gates", merged.curry());
 
         Ok(merged)
     }
@@ -589,7 +589,7 @@ where
             }
         }
 
-        // println!("Expected max_wire was {}, actual was {}", self.graph.edge_count() + self.inputs.len() + self.outputs.len(), max_wire);
+        log::warn!("Expected max_wire was {}, actual was {}", self.graph.edge_count() + self.inputs.len() + self.outputs.len(), max_wire);
         max_wire
     }
 

--- a/src/generic/circuit.rs
+++ b/src/generic/circuit.rs
@@ -512,15 +512,18 @@ where
         log::debug!("Adding missing wires...");
         // We call the `build` operation, which is necessary to make the edges in our underlying
         // graph (assuming the gates weren't already topologically sorted)
-        log::debug!("Created {} wires", merged._build()?);
+        let num_wires = merged._build()?;
+        log::debug!("Created {} wires", num_wires);
         // We undo the remappings on any IO wires for this subcircuit
         // We attempt to squash the buffer gates that we used to connect the parent circuits to
         // the subcircuits
         log::debug!("Squashing extra buffer gates");
-        log::debug!("Removed {} buffers", merged.prune());
+        let num_pruned_buffers = merged.prune();
+        log::debug!("Removed {} buffers", num_pruned_buffers);
 
         log::debug!("Currying constant gates");
-        log::debug!("Removed {} constant gates", merged.curry());
+        let num_constant_gates_removed = merged.curry();
+        log::debug!("Removed {} constant gates", num_constant_gates_removed);
 
         Ok(merged)
     }

--- a/src/generic/flattener.rs
+++ b/src/generic/flattener.rs
@@ -84,7 +84,7 @@ where
                         gate_index,
                         wire: _,
                     } => {
-                        println!("WARNING: {parent} contains a gate with an undriven input. Dropping this gate and trusting that its output won't be needed.");
+                        log::warn!("{parent} contains a gate with an undriven input. Dropping this gate and trusting that its output won't be needed.");
                         let gate = circuit
                             .graph
                             .remove_node(NodeIndex::new(gate_index))
@@ -160,7 +160,7 @@ where
             // If we haven't flattened the circuit, replace our current copy of it with a flattened
             // version
             if !is_flat {
-                println!("\nFlattening {sub_name}");
+                log::info!("Flattening {sub_name}");
                 let mut sub = self
                     .subcircuits
                     .remove(sub_name)
@@ -173,9 +173,9 @@ where
         // Now that we have one flattened copy of each subcircuit, we can flatten `top`. First, we
         // print out some debug information to help us estimate the size of the circuit (and how
         // much RAM we'll need)
-        println!("\nPerforming final flattening");
+        log::info!("Performing final flattening");
         for (name, sub) in self.subcircuits.iter() {
-            println!(
+            log::debug!(
                 "    {}: {} Gates | {} Wires | {} kb",
                 name,
                 sub.ngate(),
@@ -187,12 +187,12 @@ where
         }
 
         // Merge all of the subcircuits into the top module
-        println!("\n Top module:");
+        log::debug!("Top module:");
         let mut out = self.top.merge(&self.subcircuits)?;
 
         // Shrink the wires down into the smallest contiguous chunk of the 64-bit space as possible
         // so that they'll fit in less memory when we have to load them into Reverie.
-        println!("Minimizing wire indices");
+        log::debug!("Minimizing wire indices");
         out.minimize_wires();
         Ok(out)
     }

--- a/src/optimize/dead.rs
+++ b/src/optimize/dead.rs
@@ -28,7 +28,7 @@ pub fn eliminate_dead_code(circuit: &[Op], max_wire: usize) -> Vec<Op> {
         }
     }
 
-    println!(
+    log::info!(
         "dead: {}, total: {} ({:.2}% circuit size reduction)",
         num_dead,
         circuit.len(),

--- a/src/optimize/ram.rs
+++ b/src/optimize/ram.rs
@@ -16,7 +16,7 @@ use mcircuit::{CombineOperation as Op, CombineOperation};
 /// and always allocating the smallest available free register.
 
 pub fn register_aliasing(circuit: &[Op], max_wire: usize) -> Vec<Op> {
-    println!("Calculating time of last use...");
+    log::debug!("Calculating time of last use...");
 
     let progress = ProgressBar::new(circuit.len() as u64);
     progress.set_draw_rate(4);
@@ -47,7 +47,7 @@ pub fn register_aliasing(circuit: &[Op], max_wire: usize) -> Vec<Op> {
     let mut new_wins = Vec::with_capacity(4);
     let mut new_wouts = Vec::with_capacity(4);
 
-    println!("Aliasing registers...");
+    log::debug!("Aliasing registers...");
     let progress = ProgressBar::new(circuit.len() as u64);
     progress.set_draw_rate(4);
 
@@ -111,7 +111,7 @@ pub fn register_aliasing(circuit: &[Op], max_wire: usize) -> Vec<Op> {
     let (largest_arith, largest_bool) = largest_wires(&new_circuit);
     let max_mem = max(largest_bool, largest_arith);
 
-    println!(
+    log::debug!(
         "register use: {} / {} ({:.2} % register reduction)",
         max_mem,
         max_wire,

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -48,7 +48,7 @@ fn main() {
                 *counts.entry(key).or_insert(0) += 1;
             }
 
-            println!("{counts:?}");
+            log::debug!("{counts:?}");
         }
         "wires" => {
             let mut arith_wires: HashSet<usize> = HashSet::new();
@@ -62,14 +62,14 @@ fn main() {
                 }
             }
 
-            println!(
+            log::debug!(
                 "{{\"boolean_wires\": {}, \"arithmetic_wires\": {} }}",
                 bool_wires.len(),
                 arith_wires.len()
             )
         }
         _ => {
-            println!("Count options are: gates, wires")
+            log::debug!("Count options are: gates, wires")
         }
     }
 }


### PR DESCRIPTION
Allow more liberal use of `log::debug!`, using `log::info!` for high-level circuit transformation passes. Label warnings.